### PR TITLE
Update git-ps formula to use v0.3.0

### DIFF
--- a/Formula/git-ps.rb
+++ b/Formula/git-ps.rb
@@ -1,7 +1,7 @@
 class GitPs < Formula
   desc "Patch Stack workflow CLI extension for Git"
   homepage "https://github.com/uptech/git-ps"
-  url "https://github.com/uptech/git-ps.git", :tag => "0.2.1", :revision => "c08774dd16c1cbdcc2200c8f2b351e90e50f31ad"
+  url "https://github.com/uptech/git-ps.git", :tag => "0.3.0", :revision => "cb90fe9c255e60dd5fffce19b3eb50ef2f8f5981"
   head "https://github.com/uptech/git-ps.git"
 
   depends_on :xcode => ["10.13", :build]


### PR DESCRIPTION
I did this so that people can get the latest version of git-ps through
the tap

ps-id: 23E72D26-FA91-444C-92AB-3A8026252F2B