### PR TITLE
Include information about how the Ruby Class name should be formatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ brew tap "uptech/homebrew-oss"
 ```
 
 Once you have tapped it you can `brew search`, `brew install`, etc.
+
+## Formula Ruby Class Info
+The name of the Formula must use the following pattern to be recognized when the name of the binary is MyName:
+
+Formula Class = `Myname`


### PR DESCRIPTION
Did this because we had to publish a few extra patches when
deploying the tmptoml formula.

ps-id: 3071AC4E-C144-481B-BBED-5454D942A696